### PR TITLE
fix(stripe): Payment Method Fallback & Account Balance Display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drachenboot-app",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "private": true,
   "scripts": {
     "db:up": "docker compose up -d",

--- a/src/components/stripe/BillingContent.tsx
+++ b/src/components/stripe/BillingContent.tsx
@@ -24,6 +24,8 @@ export interface SubscriptionData {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         paymentMethod: any;
     } | null;
+    accountBalance?: number;
+    currency?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     history: any[];
 }
@@ -181,6 +183,30 @@ export const BillingContent = ({ team, subscription }: BillingContentProps) => {
                         </div>
                     )}
                     </div>
+
+                {/* Account Balance Section */}
+                {subscription.accountBalance !== undefined && subscription.accountBalance !== 0 && (
+                    <div className={`rounded-xl shadow-sm border p-6 ${
+                        subscription.accountBalance > 0 
+                        ? 'bg-red-50 dark:bg-red-900/10 border-red-200 dark:border-red-900/30 text-red-800 dark:text-red-200' 
+                        : 'bg-green-50 dark:bg-green-900/10 border-green-200 dark:border-green-900/30 text-green-800 dark:text-green-200'
+                    }`}>
+                        <h3 className="text-lg font-bold mb-2 flex items-center gap-2">
+                            {t('pro.accountBalance')}
+                        </h3>
+                        <p className="text-3xl font-black tracking-tight mb-1">
+                            {(subscription.accountBalance / 100).toFixed(2)} {(subscription.currency || 'eur').toUpperCase()}
+                        </p>
+                        
+                        {/* Minimum charge warning */}
+                        {subscription.accountBalance > 0 && subscription.accountBalance < 50 && (
+                            <div className="mt-4 flex gap-3 text-sm bg-white/60 dark:bg-black/20 p-3 rounded-lg border border-red-100 dark:border-red-900/20">
+                                <AlertCircle className="shrink-0 w-5 h-5" />
+                                <p>{t('pro.balanceMinimumNote')}</p>
+                            </div>
+                        )}
+                    </div>
+                )}
 
                 <div className="bg-white dark:bg-slate-900 rounded-xl shadow-sm border border-slate-200 dark:border-slate-800 overflow-hidden">
                         <div className="p-6 border-b border-slate-100 dark:border-slate-800">

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -108,6 +108,9 @@
     "helpStartTour": "Tour starten",
     "helpUnderstood": "Verstanden",
     "close": "Schließen",
+    "managedByOther": "Das Abonnement wird von einem anderen Teammitglied verwaltet.",
+    "accountBalance": "Kontostand",
+    "balanceMinimumNote": "Offene Beträge werden gesammelt, bis der Mindestbetrag von 0,50 € erreicht ist.",
     "guestAddTitle": "Gast hinzufügen",
     "guestName": "Gast Name",
     "weightKg": "Gewicht (kg)",
@@ -147,6 +150,18 @@
     "clTechnical": "Technische Änderungen",
     "clBugfixes": "Fehlerbehebungen",
     "changelogData": [
+        {
+            "version": "3.4.8",
+            "date": "Januar 2026",
+            "features": [
+                "Anzeige des aktuellen Kontostands auf der Abrechnungsseite hinzugefügt.",
+                "Hinweis bei kleinen offenen Beträgen unter der Mindestbuchungsmenge."
+            ],
+            "technical": [],
+            "bugfixes": [
+                "Fix: Fehlende Zahlungsmethode bei Abos mit 0€ Startbetrag wird nun durch Fallback auf Kunden-Daten korrekt angezeigt."
+            ]
+        },
         {
             "version": "3.4.7",
             "date": "Januar 2026",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -108,6 +108,9 @@
     "helpStartTour": "Start Tour",
     "helpUnderstood": "Understood",
     "close": "Close",
+    "managedByOther": "The subscription is managed by another team member.",
+    "accountBalance": "Account Balance",
+    "balanceMinimumNote": "Open amounts are collected until the minimum charge of €0.50 is reached.",
     "guestAddTitle": "Add Guest",
     "guestName": "Guest Name",
     "weightKg": "Weight (kg)",
@@ -147,6 +150,18 @@
     "clTechnical": "Technical Changes",
     "clBugfixes": "Bug Fixes",
     "changelogData": [
+        {
+            "version": "3.4.8",
+            "date": "January 2026",
+            "features": [
+                "Added account balance display on the billing page.",
+                "Added notice for small open amounts below the minimum charge threshold."
+            ],
+            "technical": [],
+            "bugfixes": [
+                "Fix: Missing payment method for subscriptions with 0€ initial charge is now correctly displayed via fallback to customer data."
+            ]
+        },
         {
             "version": "3.4.7",
             "date": "January 2026",


### PR DESCRIPTION
## Changes
- **Stripe Service**: Updated to expand customer data and use it as a fallback for the default payment method if missing on the subscription.
- **BillingContent**: Added section to display Stripe account balance.
- **Localization**: Added missing text for balance display and warnings.
- **Changelog**: Updated for version 3.4.8.

Fixes issue where the payment method was invisible for 0€ checkouts and informs users about small open balances.