### PR TITLE
fix(billing): invert account balance sign display

### DIFF
--- a/src/components/stripe/BillingContent.tsx
+++ b/src/components/stripe/BillingContent.tsx
@@ -195,7 +195,7 @@ export const BillingContent = ({ team, subscription }: BillingContentProps) => {
                             {t('pro.accountBalance')}
                         </h3>
                         <p className="text-3xl font-black tracking-tight mb-1">
-                            {(subscription.accountBalance / 100).toFixed(2)} {(subscription.currency || 'eur').toUpperCase()}
+                            {(-1 * subscription.accountBalance / 100).toFixed(2)} {(subscription.currency || 'eur').toUpperCase()}
                         </p>
                         
                         {/* Minimum charge warning */}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -149,6 +149,15 @@
     "clBugfixes": "Fehlerbehebungen",
     "changelogData": [
         {
+            "version": "3.4.9",
+            "date": "Januar 2026",
+            "features": [],
+            "technical": [],
+            "bugfixes": [
+                "Fix: Kontostand-Anzeige korrigiert (Guthaben wird jetzt positiv, offene Beträge negativ dargestellt)."
+            ]
+        },
+        {
             "version": "3.4.8",
             "date": "Januar 2026",
             "features": [

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -149,6 +149,15 @@
     "clBugfixes": "Bug Fixes",
     "changelogData": [
         {
+            "version": "3.4.9",
+            "date": "January 2026",
+            "features": [],
+            "technical": [],
+            "bugfixes": [
+                "Fix: Corrected account balance display (credit is now positive, debt is negative)."
+            ]
+        },
+        {
             "version": "3.4.8",
             "date": "January 2026",
             "features": [


### PR DESCRIPTION
Ensures account balance is displayed with inverted sign: Credit (negative Stripe balance) is shown as positive, Debt (positive Stripe balance) as negative.